### PR TITLE
Add vote event caching to reduce scrape time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ data
 cache
 _cache
 _data
+_cached_votes
+_cached_votes copy
 
 # Setting-overrides that should not be shared
 local_settings.*py
@@ -43,3 +45,6 @@ tmp.*
 pubinfo_*/
 billydata
 .idea
+
+# js
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -4,21 +4,23 @@ Adapted from https://github.com/openstates/openstates-scrapers.
 
 ## Commands
 
-<<<<<<< HEAD
 This assumes Docker is installed and running. See the OpenStates [getting started guide](https://docs.openstates.org/en/latest/contributing/getting-started.html).
 
-### Full scrape
+### Full scrape with vote event cache
 ```npm run scrape```
-or
-```docker-compose run --rm scrape mt bills --scrape```
 
 Writes to `_cache` and `_data` folders (left untracked by version control). 
 
+If you have done a local scrape before, this script will create a temporary cache in `_cached_votes` of any vote events 
+from your last scrape to avoid requesting and parsing the same vote events again. After a full scrape, this folder will be deleted.
+
+### Full scrape without vote event cache
+```npm run scrape-no-cache``` will ignore your previous scraped vote events and run a full scrape without using the cache. 
+Once you run this, you can't get your previously scraped vote events back again.
+
 ### Single bill scrape
-=======
 * [Contributor's Guide](https://docs.openstates.org/en/latest/contributing/getting-started.html)
 * [Documentation](https://docs.openstates.org/en/latest/contributing/scrapers.html)
 * [Open States Issues](https://github.com/openstates/issues/issues)
 * [Open States Discussions](https://github.com/openstates/issues/discussions)
 * [Code of Conduct](https://docs.openstates.org/en/latest/contributing/code-of-conduct.html)
->>>>>>> f7759a3fe031ca16b52a1a9e82654b7ec0f12d9c

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "mtleg-bill-scraper",
+  "version": "1.0.0",
+  "description": "Adapted from https://github.com/openstates/openstates-scrapers.",
+  "main": "index.js",
+  "scripts": {
+    "populate-vote-cache": "mkdir -p _cached_votes && [[ ! -f _data/mt/vote_event_* ]] || mv _data/mt/vote_event_* _cached_votes",
+    "scrape": "npm run populate-vote-cache && docker-compose run --rm scrape mt bills --scrape",
+    "scrape-no-cache": "docker-compose run --rm scrape mt bills --scrape",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/eidietrich/mtleg-bill-scraper.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/eidietrich/mtleg-bill-scraper/issues"
+  },
+  "homepage": "https://github.com/eidietrich/mtleg-bill-scraper#readme"
+}


### PR DESCRIPTION
If you've done a full scrape before, this will cache vote events previously downloaded and move them to `_data/mt` when they're asked for instead of re-getting vote events from afar every time.

Full scrape time: 85m
Full scrape time with cache: 28m 🥳 

`npm run scrape` will use cache by default
`npm run scrape-no-cache` will do a full clean scrape (may be handy every now and then in case a vote event is ever amended)