### PR TITLE
Fix for vote event cache fluke duplications

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Adapted from https://github.com/openstates/openstates-scrapers.",
   "main": "index.js",
   "scripts": {
-    "populate-vote-cache": "mkdir -p _cached_votes && [[ ! -f _data/mt/vote_event_* ]] || mv _data/mt/vote_event_* _cached_votes",
+    "populate-vote-cache": "mkdir -p _cached_votes && [ ! -f _data/mt/vote_event_* ] || mv _data/mt/vote_event_* _cached_votes",
     "scrape": "npm run populate-vote-cache && docker-compose run --rm scrape mt bills --scrape",
     "scrape-no-cache": "docker-compose run --rm scrape mt bills --scrape",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/scrapers/mt/bills.py
+++ b/scrapers/mt/bills.py
@@ -154,8 +154,8 @@ class MTBillScraper(Scraper, LXMLMixin):
         for f in leftover_cached_votes:
             try:
                 leftover_vote_json = json.loads(open(f).read())
-                leftover_votes.append(leftover_vote_json[pupa_id])
-                leftover_votes.append(leftover_vote_json[bill_identifier])
+                leftover_votes.append(leftover_vote_json['pupa_id'])
+                leftover_votes.append(leftover_vote_json['bill_identifier'])
                 os.remove(f)
                 delete_counter += 1
             except OSError as e:
@@ -566,7 +566,7 @@ class MTBillScraper(Scraper, LXMLMixin):
                         try: 
                             shutil.move(cached_vote, './_data/mt/')
                         except OSError as e:
-                            if "already exists" in e:
+                            if "already exists" in str(e):
                                 self.logger.warning("Vote event URL already seen attached to previous action, skipping")
                             else:
                                 raise e

--- a/scrapers/mt/bills.py
+++ b/scrapers/mt/bills.py
@@ -568,9 +568,10 @@ class MTBillScraper(Scraper, LXMLMixin):
                         except OSError as e:
                             if "already exists" in str(e):
                                 self.logger.warning("Vote event URL already seen attached to previous action, skipping")
+                                continue
                             else:
                                 raise e
-
+    
                         self.logger.info("Moved vote event from cache " + cached_vote)
                     else:
                         # Get the matching vote object.

--- a/scrapers/mt/bills.py
+++ b/scrapers/mt/bills.py
@@ -150,13 +150,20 @@ class MTBillScraper(Scraper, LXMLMixin):
         leftover_cached_votes = glob.glob('./_cached_votes/*')
 
         delete_counter = 0
+        leftover_votes = []
         for f in leftover_cached_votes:
             try:
+                leftover_vote_json = json.loads(open(f).read())
+                leftover_votes.append(leftover_vote_json[pupa_id])
+                leftover_votes.append(leftover_vote_json[bill_identifier])
                 os.remove(f)
                 delete_counter += 1
             except OSError as e:
                 print("Error deleting leftover cached votes: %s : %s" % (f, e.strerror))
-        self.logger.info("Deleted " + str(delete_counter) + " leftover cached vote events")
+        if delete_counter > 0:
+            self.logger.info("Deleted " + str(delete_counter) + " leftover cached vote events")
+            self.logger.info("This is likely the result of this/these vote event URL(s) being incorrectly duplicated in this/these bills:")
+            self.logger.info(leftover_votes)
 
         cached_votes_dir = './_cached_votes'
         try:
@@ -556,7 +563,14 @@ class MTBillScraper(Scraper, LXMLMixin):
                     if any(vote_url[0] in s for s in self.cached_vote_urls):
                         # Move cached vote event to /_data/mt
                         cached_vote = "./_cached_votes/vote_event_" + self.cached_vote_urls_to_ids[vote_url[0]] + ".json"
-                        shutil.move(cached_vote, './_data/mt/')
+                        try: 
+                            shutil.move(cached_vote, './_data/mt/')
+                        except OSError as e:
+                            if "already exists" in e:
+                                self.logger.warning("Vote event URL already seen attached to previous action, skipping")
+                            else:
+                                raise e
+
                         self.logger.info("Moved vote event from cache " + cached_vote)
                     else:
                         # Get the matching vote object.


### PR DESCRIPTION
If a vote event URL is incorrectly assigned to two different bill actions, the cache errors on the 2nd+ time the vote event URL is asked for from the cache, because the ID associated with it (file name) has already been moved.

This happened on 3/18:
[the "3rd Reading Passed" action on 3/18/2021](http://laws.leg.mt.gov/legprd/LAW0210W$BSIV.ActionQuery?P_BILL_NO1=525&P_BLTP_BILL_TYP_CD=HB&Z_ACTION=Find&P_SESS=20211) (incorrect duplicate)
[the "2nd Reading Passed" action on 1/21/2021](http://laws.leg.mt.gov/legprd/LAW0210W$BSIV.ActionQuery?P_BILL_NO1=92&P_BLTP_BILL_TYP_CD=HB&Z_ACTION=Find&P_SESS=20211) (legit)

This PR updates `bills.py` so that this error is caught and the duplicate is skipped. At the end of the run, the duplicate vote URL/bill identifier will be logged so Eric can ping the powers that be. 

Also fixes the `populate-vote-cache` NPM command.